### PR TITLE
mark-devkit: Bump virtual/jpeg-0-r3

### DIFF
--- a/virtual/jpeg/jpeg-0-r3.ebuild
+++ b/virtual/jpeg/jpeg-0-r3.ebuild
@@ -1,0 +1,15 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit multilib-build
+
+DESCRIPTION="Virtual to select between libjpeg-turbo and IJG jpeg for source-based packages"
+SLOT="0"
+KEYWORDS="*"
+IUSE="static-libs"
+
+RDEPEND="|| (
+		>=media-libs/libjpeg-turbo-1.5.3-r2:0[static-libs?,${MULTILIB_USEDEP}]
+		>=media-libs/jpeg-9d:0[static-libs?,${MULTILIB_USEDEP}]
+		)"


### PR DESCRIPTION
Automatic bump of package virtual/jpeg-0-r3 for branch mark-xl by mark-bot