### PR TITLE
mark-devkit: Bump x11-proto/dri2proto-2.8-r3

### DIFF
--- a/x11-proto/dri2proto/dri2proto-2.8-r3.ebuild
+++ b/x11-proto/dri2proto/dri2proto-2.8-r3.ebuild
@@ -12,7 +12,8 @@ SLOT="0/stub"
 PDEPEND="|| (
 	=x11-base/xorg-proto-2018.4_p20180627-r2
 	=x11-base/xorg-proto-2019.2
-	=x11-base/xorg-proto-2023.2 )"
+	=x11-base/xorg-proto-2023.2
+	=x11-base/xorg-proto-2024.1 )"
 DEPEND="${RDEPEND}"
 
 S="${WORKDIR}"


### PR DESCRIPTION
Automatic bump of package x11-proto/dri2proto-2.8-r3 for branch mark-xl by mark-bot