### PR TITLE
mark-devkit: Bump x11-proto/xproto-7.0.33-r3

### DIFF
--- a/x11-proto/xproto/xproto-7.0.33-r3.ebuild
+++ b/x11-proto/xproto/xproto-7.0.33-r3.ebuild
@@ -9,7 +9,9 @@ KEYWORDS="*"
 
 SLOT="0/stub"
 
-PDEPEND="=x11-base/xorg-proto-2023.2"
+PDEPEND="|| (
+	=x11-base/xorg-proto-2023.2
+	=x11-base/xorg-proto-2024.1 )"
 DEPEND="${RDEPEND}"
 
 S="${WORKDIR}"


### PR DESCRIPTION
Automatic bump of package x11-proto/xproto-7.0.33-r3 for branch mark-xl by mark-bot