### PR TITLE
mark-devkit: Bump x11-apps/mkfontdir-1.2.0

### DIFF
--- a/x11-apps/mkfontdir/mkfontdir-1.2.0.ebuild
+++ b/x11-apps/mkfontdir/mkfontdir-1.2.0.ebuild
@@ -1,0 +1,14 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="create an index of X font files in a directory"
+HOMEPAGE="https://www.x.org/wiki/ https://gitlab.freedesktop.org/xorg/app/mkfontdir"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="*"
+IUSE=""
+
+RDEPEND=">=x11-apps/mkfontscale-1.2.0"
+DEPEND="${RDEPEND}"


### PR DESCRIPTION
Automatic bump of package x11-apps/mkfontdir-1.2.0 for branch mark-xl by mark-bot