### PR TITLE
mark-devkit: Bump virtual/opengl-7.0-r5

### DIFF
--- a/virtual/opengl/opengl-7.0-r5.ebuild
+++ b/virtual/opengl/opengl-7.0-r5.ebuild
@@ -1,0 +1,11 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Virtual for OpenGL implementation"
+SLOT="0"
+KEYWORDS="*"
+
+RDEPEND="
+	>=media-libs/libglvnd-1.2.0
+"


### PR DESCRIPTION
Automatic bump of package virtual/opengl-7.0-r5 for branch mark-xl by mark-bot