### PR TITLE
mark-devkit: Bump virtual/ttf-fonts-1-r1

### DIFF
--- a/virtual/ttf-fonts/ttf-fonts-1-r1.ebuild
+++ b/virtual/ttf-fonts/ttf-fonts-1-r1.ebuild
@@ -1,0 +1,18 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+DESCRIPTION="Virtual for Serif/Sans/Monospace font packages"
+SLOT="0"
+KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 s390 sh sparc x86 ~x64-cygwin ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+
+RDEPEND="|| (
+		media-fonts/liberation-fonts
+		media-fonts/source-pro
+		media-fonts/dejavu
+		media-fonts/croscorefonts
+		media-fonts/droid
+		media-fonts/freefont
+		media-fonts/corefonts
+	)"


### PR DESCRIPTION
Automatic bump of package virtual/ttf-fonts-1-r1 for branch mark-xl by mark-bot