### PR TITLE
mark-devkit: Bump virtual/glu-9.0-r2

### DIFF
--- a/virtual/glu/glu-9.0-r2.ebuild
+++ b/virtual/glu/glu-9.0-r2.ebuild
@@ -1,0 +1,17 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit multilib-build
+
+DESCRIPTION="Virtual for OpenGL utility library"
+SLOT="0"
+KEYWORDS="alpha amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+
+RDEPEND="
+	|| (
+		>=media-libs/glu-9.0.0-r1[${MULTILIB_USEDEP}]
+		media-libs/opengl-apple
+		dev-util/mingw64-runtime
+	)"


### PR DESCRIPTION
Automatic bump of package virtual/glu-9.0-r2 for branch mark-xl by mark-bot