### PR TITLE
mark-devkit: Bump x11-proto/dpmsproto-1.2-r2

### DIFF
--- a/x11-proto/dpmsproto/dpmsproto-1.2-r2.ebuild
+++ b/x11-proto/dpmsproto/dpmsproto-1.2-r2.ebuild
@@ -1,0 +1,22 @@
+# Distributed under the terms of the GNU General Public License v2
+EAPI=6
+
+inherit multilib-minimal
+
+DESCRIPTION="X.Org Protocol ${proto} package stub ."
+
+KEYWORDS="*"
+
+SLOT="0/stub"
+
+PDEPEND="=x11-base/xorg-proto-2023.2"
+DEPEND="${RDEPEND}"
+
+S="${WORKDIR}"
+
+multilib_src_configure() { return 0; }
+src_configure() { return 0; }
+multilib_src_compile() { return 0; }
+src_compile() { return 0; }
+multilib_src_install() { return 0; }
+src_install() { return 0; }


### PR DESCRIPTION
Automatic bump of package x11-proto/dpmsproto-1.2-r2 for branch mark-iii by mark-bot