### PR TITLE
mark-devkit: Bump x11-apps/bitmap-1.0.9-r1

### DIFF
--- a/x11-apps/bitmap/bitmap-1.0.9-r1.ebuild
+++ b/x11-apps/bitmap/bitmap-1.0.9-r1.ebuild
@@ -14,9 +14,7 @@ RDEPEND="x11-libs/libX11
 	x11-libs/libXaw
 	x11-libs/libXt
 	x11-misc/xbitmaps"
-DEPEND="${RDEPEND}
-	x11-misc/util-macros
-"
+DEPEND="${RDEPEND}"
 
 src_unpack() {
 	xorg-3_src_unpack


### PR DESCRIPTION
Automatic bump of package x11-apps/bitmap-1.0.9-r1 for branch mark-unstable by mark-bot