### PR TITLE
mark-devkit: Bump x11-base/xorg-proto-2023.2-r1

### DIFF
--- a/x11-base/xorg-proto/xorg-proto-2023.2-r1.ebuild
+++ b/x11-base/xorg-proto/xorg-proto-2023.2-r1.ebuild
@@ -45,6 +45,7 @@ RDEPEND="
     =x11-proto/xf86bigfontproto-1.2.0*:0/stub
     =x11-proto/xf86dgaproto-2.1*:0/stub
     =x11-proto/xf86driproto-2.1.1*:0/stub
+    =x11-proto/xf86miscproto-0.9.3*:0/stub
     =x11-proto/xf86rushproto-1.1.2*:0/stub
     =x11-proto/xf86vidmodeproto-2.3.1*:0/stub
     =x11-proto/xineramaproto-1.2.1*:0/stub


### PR DESCRIPTION
Automatic bump of package x11-base/xorg-proto-2023.2-r1 for branch mark-unstable by mark-bot