### PR TITLE
mark-devkit: Bump media-libs/alsa-lib-1.2.11-r1

### DIFF
--- a/media-libs/alsa-lib/alsa-lib-1.2.11-r1.ebuild
+++ b/media-libs/alsa-lib/alsa-lib-1.2.11-r1.ebuild
@@ -24,7 +24,7 @@ RDEPEND="python? ( ${PYTHON_DEPS} )
 DEPEND="${RDEPEND}"
 
 PATCHES=(
-	"${REPODIR}/media-sound/files/${PN}/${PN}-1.1.6-missing_files.patch" #652422
+	"${FILESDIR}/${PN}-1.1.6-missing_files.patch" #652422
 )
 
 pkg_setup() {

--- a/media-libs/alsa-lib/files/alsa-lib-1.1.6-missing_files.patch
+++ b/media-libs/alsa-lib/files/alsa-lib-1.1.6-missing_files.patch
@@ -1,0 +1,196 @@
+https://bugs.gentoo.org/652422
+
+--- alsa-lib-1.1.6/src/conf/cards/aliases.alisp
++++ alsa-lib-1.1.6/src/conf/cards/aliases.alisp
+@@ -0,0 +1,29 @@
++(setq snd_card_aliases_array
++  (
++    ("YMF724" 		. "YMF744")
++    ("YMF724F"		. "YMF744")
++    ("YMF740"		. "YMF744")
++    ("YMF740C"		. "YMF744")
++    ("YMF754"		. "YMF744")
++    ("CMIPCI"		. "CMI8338")
++    ("CMI8738"		. "CMI8338")
++    ("CMI8738-MC4"	. "CMI8738-MC6")
++    ("E-mu APS"		. "EMU10K1")
++    ("GUS Max"		. "GUS")
++    ("GUS ACE" 		. "GUS")
++    ("GUS Extreme"	. "GUS")
++    ("AMD InterWave"	. "GUS")
++    ("Dynasonic 3-D"	. "GUS")
++    ("InterWave STB"	. "GUS")
++  )
++)
++
++(defun snd_card_alias (cardname)
++  (setq r (assq cardname snd_card_aliases_array))
++  (setq r (if (null r) cardname r))
++  (unsetq r)
++)
++
++(defun snd_card_alias_unset ()
++  (unsetq snd_card_aliases_array snd_card_alias)
++)
+--- alsa-lib-1.1.6/src/conf/cards/SI7018/sndoc-mixer.alisp
++++ alsa-lib-1.1.6/src/conf/cards/SI7018/sndoc-mixer.alisp
+@@ -0,0 +1,11 @@
++;
++; SiS SI7018 mixer abstract layer
++;
++; Copyright (c) 2003 Jaroslav Kysela <perex@perex.cz>
++; License: GPL v2 (http://www.gnu.org/licenses/gpl.html)
++;
++
++(defun sndoc_mixer_open (hctl pcm)
++  (princ "sndoc_mixer_open: hctl=" hctl " pcm=" pcm "\n")
++  0
++)
+--- alsa-lib-1.1.6/src/conf/cards/SI7018/sndop-mixer.alisp
++++ alsa-lib-1.1.6/src/conf/cards/SI7018/sndop-mixer.alisp
+@@ -0,0 +1,11 @@
++;
++; SiS SI7018 mixer abstract layer
++;
++; Copyright (c) 2003 Jaroslav Kysela <perex@perex.cz>
++; License: GPL v2 (http://www.gnu.org/licenses/gpl.html)
++;
++
++(defun sndop_mixer_open (hctl pcm)
++  (princ "sndop_mixer_open: hctl=" hctl " pcm=" pcm "\n")
++  0
++)
+--- alsa-lib-1.1.6/src/conf/smixer.conf
++++ alsa-lib-1.1.6/src/conf/smixer.conf
+@@ -0,0 +1,13 @@
++_full smixer-python.so
++usb {
++	searchl "USB"
++	lib smixer-usb.so
++}
++ac97 {
++	searchl "AC97a:"
++	lib smixer-ac97.so
++}
++hda {
++	searchl "HDA:"
++	lib smixer-hda.so
++}
+--- alsa-lib-1.1.6/src/conf/sndo-mixer.alisp
++++ alsa-lib-1.1.6/src/conf/sndo-mixer.alisp
+@@ -0,0 +1,115 @@
++;
++; Toplevel configuration for the ALSA Ordinary Mixer Interface
++;
++; Copyright (c) 2003 Jaroslav Kysela <perex@perex.cz>
++; License: GPL v2 (http://www.gnu.org/licenses/gpl.html)
++;
++
++(defun sndo_include (hctl stream)
++  (setq info (Acall "ctl_card_info" (Acall "hctl_ctl" hctl)))
++  (if (= (Aerror info) 0)
++    (progn
++      (setq info (Aresult info))
++      (setq driver (cdr (assq "driver" (unsetq info))))
++      (setq file (concat (path "data") "/alsa/cards/" (snd_card_alias driver) "/sndo" stream "-mixer.alisp"))
++      (setq r (include file))
++      (when (= r -2) (Asyserr "unable to find file " file))
++    )
++    (setq r (Aerror info))
++  )
++  (unsetq info driver file r)
++)
++
++(defun sndo_mixer_open_fcn (hctl stream pcm)
++  (setq fcn (concat "sndo" stream "_mixer_open"))
++  (setq r (if (exfun fcn) (funcall fcn hctl pcm) 0))
++  (when (= r 0)
++    (setq hctls (if hctls (cons hctls (cons hctl)) hctl))
++  )
++  (unsetq fcn r)
++)
++
++(defun sndo_mixer_open_hctl (name stream pcm)
++  (setq hctl (Acall "hctl_open" name nil))
++  (setq r (Aerror hctl))
++  (when (= r 0)
++    (setq hctl (Aresult hctl))
++    (setq r (sndo_include hctl stream))
++    (if (= r 0)
++       (setq r (sndo_mixer_open_fcn hctl stream pcm))
++       (Acall "hctl_close" hctl)
++    )
++  )
++  (unsetq hctl r)
++)
++
++(defun sndo_mixer_open_virtual (name stream pcm)
++  (setq file (concat (path "data") "/alsa/virtual/" name "/sndo" stream "-mixer.alisp"))
++  (setq r (include file))
++  (when (= r -2) (Asyserr "unable to find file " file))
++  (when (= r 0) (setq r (sndo_mixer_open_fcn nil stream pcm)))
++  (unsetq file r)
++)
++
++(defun sndo_mixer_open1 (name stream)
++  (if (compare-strings name 0 2 "hw:" 0 2)
++    (sndo_mixer_open_hctl name stream nil)
++    (sndo_mixer_open_virtual name stream nil)
++  )
++)
++
++(defun sndo_mixer_open (pname cname)
++  (setq r (sndo_mixer_open1 pname "p"))
++  (when (= r 0) (setq r (sndo_mixer_open1 cname "c")))
++  (when (!= r 0) (sndo_mixer_close))
++  (unsetq sndo_mixer_open
++	  sndo_mixer_open_pcm sndo_mixer_open_pcm1
++          sndo_mixer_open_virtual sndo_mixer_open_fcn
++	  sndo_include r)
++)
++
++(defun sndo_mixer_open_pcm1 (pcm stream)
++  (setq info (Acall "pcm_info" pcm))
++  (setq r (Aerror info))
++  (when (= r 0)
++    (setq info (Aresult info))
++    (setq card (cdr (assq "card" info)))
++    (setq r
++      (if (< card 0)
++	(sndo_mixer_open_virtual (Acall "pcm_name" pcm) stream pcm)
++        (sndo_mixer_open_hctl (format "hw:%i" card) stream pcm)
++      )
++    )
++  )
++  (unsetq info card r)
++)
++
++(defun sndo_mixer_open_pcm (ppcm cpcm)
++  (setq r (sndo_mixer_open_pcm1 ppcm "p"))
++  (when (= r 0) (setq r (sndo_mixer_open_pcm1 cpcm "c")))
++  (when (!= r 0) (sndo_mixer_close))
++  (unsetq sndo_mixer_open
++	  sndo_mixer_open_pcm sndo_mixer_open_pcm1
++          sndo_mixer_open_virtual sndo_mixer_open_fcn
++	  sndo_include r)
++)
++
++(defun sndo_mixer_close1 (hctl stream)
++  (when hctl
++    (progn
++      (setq fcn (concat "sndo" stream "_mixer_close"))
++      (when (exfun fcn) (funcall fcn hctl))
++      (unsetq fcn)
++      (Acall "hctl_close" hctl)
++    )
++  )
++)
++
++(defun sndo_mixer_close nil
++  (sndo_mixer_close1 (nth 1 hctls) "c")
++  (sndo_mixer_close1 (nth 0 hctls) "p")
++  (snd_card_alias_unset)
++  (unsetq hctls)
++)
++
++(include (concat (path "data") "/alsa/cards/aliases.alisp"))


### PR DESCRIPTION
Automatic bump of package media-libs/alsa-lib-1.2.11-r1 for branch mark-xl by mark-bot