### PR TITLE
mark-devkit: [mark-unstable] Bump x11-libs/libXau-1.0.12-r1

### DIFF
--- a/x11-libs/libXau/libXau-1.0.12-r1.ebuild
+++ b/x11-libs/libXau/libXau-1.0.12-r1.ebuild
@@ -13,11 +13,6 @@ KEYWORDS="*"
 BDEPEND="virtual/pkgconfig
 	
 "
-RDEPEND="x11-libs/libX11
-	x11-libs/libXext
-	
-	
-"
 DEPEND="${RDEPEND}
 	sys-devel/autoconf
 	sys-devel/automake


### PR DESCRIPTION
Automatic bump of package x11-libs/libXau-1.0.12-r1 for branch mark-unstable by mark-bot