### PR TITLE
mark-devkit: [mark-xl] Bump app-accessibility/at-spi2-atk-2.46.0

### DIFF
--- a/app-accessibility/at-spi2-atk/at-spi2-atk-2.46.0.ebuild
+++ b/app-accessibility/at-spi2-atk/at-spi2-atk-2.46.0.ebuild
@@ -1,0 +1,14 @@
+# Distributed under the terms of the GNU General Public License v2
+# Autogen by MARK Devkit
+
+EAPI=7
+
+DESCRIPTION="Gtk module for bridging AT-SPI to Atk Metadata"
+HOMEPAGE="https://wiki.gnome.org/Accessibility"
+SLOT="2"
+KEYWORDS="*"
+RDEPEND=">=app-accessibility/at-spi2-core-2.46.0
+	
+"
+
+# vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package app-accessibility/at-spi2-atk-2.46.0 for branch mark-xl by mark-bot