### PR TITLE
mark-devkit: [mark-31] Bump x11-libs/mx-1.4.7-r3

### DIFF
--- a/x11-libs/mx/mx-1.4.7-r3.ebuild
+++ b/x11-libs/mx/mx-1.4.7-r3.ebuild
@@ -29,7 +29,6 @@ RDEPEND="
 	startup-notification? ( >=x11-libs/startup-notification-0.9 )
 "
 DEPEND="${RDEPEND}
-	dev-util/glib-utils
 	>=dev-util/gtk-doc-am-1.14
 	>=dev-util/intltool-0.35.0
 	sys-devel/gettext


### PR DESCRIPTION
Automatic bump of package x11-libs/mx-1.4.7-r3 for branch mark-31 by mark-bot