### PR TITLE
mark-devkit: [mark-31] Bump dev-libs/libwacom-2.17.0-r1

### DIFF
--- a/dev-libs/libwacom/libwacom-2.17.0-r1.ebuild
+++ b/dev-libs/libwacom/libwacom-2.17.0-r1.ebuild
@@ -15,7 +15,7 @@ IUSE="doc"
 BDEPEND="${PYTHON_DEPS}
 	virtual/pkgconfig
 	doc? (
-	  app-text/doxygen
+	  app-doc/doxygen
 	)
 	
 "


### PR DESCRIPTION
Automatic bump of package dev-libs/libwacom-2.17.0-r1 for branch mark-31 by mark-bot