### PR TITLE
mark-devkit: [mark-31] Bump x11-base/xorg-proto-2024.1-r1

### DIFF
--- a/x11-base/xorg-proto/xorg-proto-2024.1-r1.ebuild
+++ b/x11-base/xorg-proto/xorg-proto-2024.1-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://www.x.org/releases/individual/proto/xorgproto-2024.1.tar.xz -> 
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="*"
-S=""${WORKSPACE}"/xorgproto"
+S="${WORKDIR}/xorgproto-2024.1"
 src_configure() {
 	local emesonargs=(
 	  --datadir=/usr/share


### PR DESCRIPTION
Automatic bump of package x11-base/xorg-proto-2024.1-r1 for branch mark-31 by mark-bot