### PR TITLE
mark-devkit: [mark-31] Bump x11-libs/libxcb-1.17.0-r2

### DIFF
--- a/x11-libs/libxcb/libxcb-1.17.0-r2.ebuild
+++ b/x11-libs/libxcb/libxcb-1.17.0-r2.ebuild
@@ -51,7 +51,8 @@ src_configure() {
 	  --enable-shared
 	  ${no_static}
 	  $(use_enable xkb)
---enable-xinput
+	  --enable-xinput
+	  --disable-devel-docs
 	 )
 	econf "${econfargs[@]}"
 }


### PR DESCRIPTION
Automatic bump of package x11-libs/libxcb-1.17.0-r2 for branch mark-31 by mark-bot